### PR TITLE
Health check added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ import (
 func main() {
 	parse.Initialize("APP_ID", "REST_KEY", "MASTER_KEY") // rest and master keys are optional
 	parse.ServerURL("https://SERVER_URL/PATH")
+	serverHealthCheck, err := parse.ServerHealthCheck()
+	if serverHealthCheck["status"] != "ok" {
+		panic(err)
+	}
 	user := parse.User{}
 	q, err := parse.NewQuery(&user)
 	if err != nil {

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ import (
 func main() {
 	parse.Initialize("APP_ID", "REST_KEY", "MASTER_KEY") // rest and master keys are optional
 	parse.ServerURL("https://SERVER_URL/PATH")
-	serverHealthCheck, err := parse.ServerHealthCheck()
-	if serverHealthCheck["status"] != "ok" {
+	resp, err := parse.ServerHealthCheck()
+	if err != nil {
 		panic(err)
 	}
 	user := parse.User{}

--- a/health_check.go
+++ b/health_check.go
@@ -1,0 +1,53 @@
+package parse
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+const HealthCheckEndPoint = "/health"
+
+type healthCheckT struct {
+}
+
+func ServerHealthCheck() (map[string]string, error) {
+
+	body, err := defaultClient.doRequest(&healthCheckT{})
+	if err != nil {
+		return map[string]string{"status": "fail"}, err
+	}
+	data := map[string]string{}
+	if err := json.Unmarshal(body, &data); err != nil {
+		return map[string]string{"status": "fail"}, err
+	}
+	return map[string]string{"status": "ok"}, nil
+}
+
+func (h *healthCheckT) method() string {
+	return "GET"
+}
+
+func (h *healthCheckT) endpoint() (string, error) {
+
+	u := url.URL{}
+	u.Scheme = ParseScheme
+	u.Host = parseHost
+	u.Path = ParsePath + HealthCheckEndPoint
+	return u.String(), nil
+}
+
+func (h *healthCheckT) body() (string, error) {
+	return "", nil
+}
+
+func (h *healthCheckT) useMasterKey() bool {
+	return false
+}
+
+func (h *healthCheckT) session() *sessionT {
+	return nil
+}
+
+func (h *healthCheckT) contentType() string {
+	return "application/json"
+}

--- a/health_check.go
+++ b/health_check.go
@@ -10,17 +10,18 @@ const HealthCheckEndPoint = "/health"
 type healthCheckT struct {
 }
 
-func ServerHealthCheck() (map[string]string, error) {
+// To check if the server is up and running.
+func ServerHealthCheck() (map[string]interface{}, error) {
 
 	body, err := defaultClient.doRequest(&healthCheckT{})
 	if err != nil {
-		return map[string]string{"status": "fail"}, err
+		return nil, err
 	}
-	data := map[string]string{}
-	if err := json.Unmarshal(body, &data); err != nil {
-		return map[string]string{"status": "fail"}, err
+	resp := map[string]interface{}{}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, err
 	}
-	return map[string]string{"status": "ok"}, nil
+	return resp, nil
 }
 
 func (h *healthCheckT) method() string {

--- a/health_check_test.go
+++ b/health_check_test.go
@@ -10,11 +10,11 @@ import (
 func TestServerHealthCheckStatusIsOk(t *testing.T) {
 
 	setupTestServer(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, `{"status":"ok"}`)
+		fmt.Fprintf(w, `{"status": "ok"}`)
 	})
 	defer teardownTestServer()
 
-	expected := map[string]string{"status": "ok"}
+	expected := map[string]interface{}{"status": "ok"}
 	result, err := ServerHealthCheck()
 	if err != nil {
 		t.Error("Error must be nil while server status is ok!")
@@ -32,12 +32,12 @@ func TestServerHealthCheckStatusIsNotOk(t *testing.T) {
 	})
 	defer teardownTestServer()
 
-	expected := map[string]string{"status": "fail"}
 	result, err := ServerHealthCheck()
 	if err == nil {
 		t.Error("Error must be available while server status is not ok!")
 	}
-	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("ServerHealthCheck result is not formatted!")
+
+	if result != nil {
+		t.Errorf("ServerHealthCheck must return nil as response, while server status is not ok!")
 	}
 }

--- a/health_check_test.go
+++ b/health_check_test.go
@@ -1,0 +1,43 @@
+package parse
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestServerHealthCheckStatusIsOk(t *testing.T) {
+
+	setupTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"status":"ok"}`)
+	})
+	defer teardownTestServer()
+
+	expected := map[string]string{"status": "ok"}
+	result, err := ServerHealthCheck()
+	if err != nil {
+		t.Error("Error must be nil while server status is ok!")
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("ServerHealthCheck result is not formatted!")
+	}
+}
+
+func TestServerHealthCheckStatusIsNotOk(t *testing.T) {
+
+	setupTestServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusGatewayTimeout)
+		fmt.Fprintf(w, "")
+	})
+	defer teardownTestServer()
+
+	expected := map[string]string{"status": "fail"}
+	result, err := ServerHealthCheck()
+	if err == nil {
+		t.Error("Error must be available while server status is not ok!")
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("ServerHealthCheck result is not formatted!")
+	}
+}


### PR DESCRIPTION
`ServerHealthCheck` function added to connect to parse server and get the response from `/health` endpoint.

you can find `/health` endpoint in the following link:
https://github.com/parse-community/parse-server/blob/b64640c5705f733798783e68d216e957044ef23c/src/ParseServer.js#L169